### PR TITLE
[feat] react-navigation/material-bottom-tabs 으로 변경

### DIFF
--- a/ios/muscleman/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/muscleman/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,37 +2,52 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.0.7",
+    "@react-navigation/material-bottom-tabs": "^6.0.7",
     "@react-navigation/native": "^6.0.4",
     "@react-navigation/native-stack": "^6.2.2",
     "react": "17.0.2",
     "react-native": "0.66.0",
     "react-native-dotenv": "^3.2.0",
     "react-native-elements": "^3.4.2",
+    "react-native-paper": "^4.9.2",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.8.0",
     "react-native-vector-icons": "^8.1.0"

--- a/src/navigations/MainNavigation.tsx
+++ b/src/navigations/MainNavigation.tsx
@@ -1,54 +1,32 @@
 import React from 'react';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createMaterialBottomTabNavigator } from '@react-navigation/material-bottom-tabs';
 import HomeScreen from '@src/screens/HomeScreen';
 import PlansScreen from '@src/screens/PlansScreen';
 import ProfileScreen from '@src/screens/Profile';
 import { MainTabParamList, RootStackParamList } from '@src/types/navigation';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Icon, useTheme } from 'react-native-elements';
-import { IconProps } from 'react-native-elements/dist/icons/Icon';
 
-const Tab = createBottomTabNavigator<MainTabParamList>();
+const Tab = createMaterialBottomTabNavigator<MainTabParamList>();
 
 type P = NativeStackScreenProps<RootStackParamList, 'Main'> & {};
 
 const MainNavigation: React.FC<P> = () => {
   const { theme } = useTheme();
-  const getIcon = (
-    type: 'home' | 'plans' | 'profile',
-    focused: boolean,
-  ): React.ReactNode => {
-    let iconProps: IconProps = {
-      name: '',
-      color: focused ? theme.colors?.primary : theme.colors?.greyOutline,
-      type: undefined,
-    };
-
-    switch (type) {
-      case 'home':
-        iconProps.name = 'home';
-        iconProps.type = 'oction';
-        break;
-      case 'plans':
-        iconProps.name = 'calendar-today';
-        break;
-      case 'profile':
-        iconProps.name = 'person-circle-outline';
-        iconProps.type = 'ionicon';
-        break;
-    }
-
-    return <Icon {...iconProps} />;
-  };
 
   return (
-    <Tab.Navigator>
+    <Tab.Navigator
+      shifting={true}
+      activeColor={theme.colors?.white}
+      inactiveColor={theme.colors?.greyOutline}>
       <Tab.Screen
         name="Home"
         component={HomeScreen}
         options={{
           tabBarLabel: '홈',
-          tabBarIcon: ({ focused }) => getIcon('home', focused),
+          tabBarIcon: ({ color }) => (
+            <Icon name="home" type="oction" color={color} />
+          ),
         }}
       />
       <Tab.Screen
@@ -56,7 +34,7 @@ const MainNavigation: React.FC<P> = () => {
         component={PlansScreen}
         options={{
           tabBarLabel: '계획',
-          tabBarIcon: ({ focused }) => getIcon('plans', focused),
+          tabBarIcon: 'calendar-today',
         }}
       />
       <Tab.Screen
@@ -64,7 +42,9 @@ const MainNavigation: React.FC<P> = () => {
         component={ProfileScreen}
         options={{
           tabBarLabel: '내정보',
-          tabBarIcon: ({ focused }) => getIcon('profile', focused),
+          tabBarIcon: ({ color }) => (
+            <Icon name="person-circle-outline" type="ionicon" color={color} />
+          ),
         }}
       />
     </Tab.Navigator>

--- a/yarn.lock
+++ b/yarn.lock
@@ -745,6 +745,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@callstack/react-theme-provider@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@callstack/react-theme-provider/-/react-theme-provider-3.0.6.tgz#7dac483037e27e28676bdf1431ba87b88f21118f"
+  integrity sha512-wwKMXfmklfogpalNZT0W+jh76BIquiYUiQHOaPmt/PCyCEP/E6rP+e7Uie6mBZrfkea9WJYJ+mus6r+45JAEhg==
+  dependencies:
+    deepmerge "^3.2.0"
+    hoist-non-react-statics "^3.3.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -1201,6 +1209,13 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.1.2.tgz#82d8978489e47e7c54f67c453ba4a124046fe253"
   integrity sha512-PbPCleC1HpUlXtuP0DFNCNTEhRLd6lmB0KxY0SGRGqCemS3HpG/PajEQ1LDe7S51M03a1tDby1MfKTkNanUXAg==
+
+"@react-navigation/material-bottom-tabs@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@react-navigation/material-bottom-tabs/-/material-bottom-tabs-6.0.7.tgz#30f9d60e344eb4e3b1f68732715dc360755edbbd"
+  integrity sha512-EjaetcI+kgxtImLm+zA5SiNoLk2SKCqxEinCjYpBhlKRU5i/Mt+VXJbuvMFSJNuPnjZfD275N9Ql+YqyKnZMxg==
+  dependencies:
+    "@react-navigation/elements" "^1.1.2"
 
 "@react-navigation/native-stack@^6.2.2":
   version "6.2.2"
@@ -3323,7 +3338,7 @@ hermes-profile-transformer@^0.0.6:
   dependencies:
     source-map "^0.7.3"
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5534,6 +5549,20 @@ react-native-elements@^3.4.2:
     opencollective-postinstall "^2.0.3"
     react-native-ratings "8.0.4"
     react-native-size-matters "^0.3.1"
+
+react-native-iphone-x-helper@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
+  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
+
+react-native-paper@^4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-4.9.2.tgz#6ecdd81acf2cf4d6d5f0247d4c1812dea93eade0"
+  integrity sha512-J7FRsd0YblQawtuj9I46F//apZHadsCKk6jWpc6njFTYdgUeCdkR8KgEto7cp2WxbcGNELx7KGwPQ4zAgX746A==
+  dependencies:
+    "@callstack/react-theme-provider" "^3.0.6"
+    color "^3.1.2"
+    react-native-iphone-x-helper "^1.3.1"
 
 react-native-ratings@8.0.4:
   version "8.0.4"


### PR DESCRIPTION
### 작업 개요
`MainNavigation`의 `react-navigation/bottom-tabs`를 `react-navigation/material-bottom-tabs`으로 변경

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- [@react-navigation/material-bottom-tabs](https://www.npmjs.com/package/@react-navigation/material-bottom-tabs) 설치
- [react-native-paper](https://callstack.github.io/react-native-paper/) 설치
- `MainNavigation`에 `createBottomTabNavigator`을 `createMaterialBottomTabNavigator`으로 변경

resolve #15

