### PR TITLE
[feat] react-native-stack-flash-message 설치

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -274,6 +274,8 @@ PODS:
     - glog
   - react-native-safe-area-context (3.3.2):
     - React-Core
+  - react-native-stack-flash-message (1.3.0):
+    - React-Core
   - React-perflogger (0.66.0)
   - React-RCTActionSheet (0.66.0):
     - React-Core/RCTActionSheetHeaders (= 0.66.0)
@@ -390,6 +392,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-stack-flash-message (from `../node_modules/react-native-stack-flash-message`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
@@ -460,6 +463,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-stack-flash-message:
+    :path: "../node_modules/react-native-stack-flash-message"
   React-perflogger:
     :path: "../node_modules/react-native/ReactCommon/reactperflogger"
   React-RCTActionSheet:
@@ -523,6 +528,7 @@ SPEC CHECKSUMS:
   React-jsinspector: be95ad424ba9f7b817aff22732eb9b1b810a000a
   React-logger: 9a9cd87d4ea681ae929b32ef580638ff1b50fb24
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
+  react-native-stack-flash-message: 40b12d1d80a29863535fce790ae4eae4c75b95cd
   React-perflogger: 1f554c2b684e2f484f9edcdfdaeedab039fbaca8
   React-RCTActionSheet: 610d5a5d71ab4808734782c8bca6a12ec3563672
   React-RCTAnimation: ec6ed97370ace32724c253f29f0586cafcab8126

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-native-paper": "^4.9.2",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.8.0",
+    "react-native-stack-flash-message": "^1.3.0",
     "react-native-vector-icons": "^8.1.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,13 @@ import theme from '@src/theme';
 import { useColorScheme } from 'react-native';
 import { ApolloProvider } from '@apollo/client';
 import { client } from '@src/client';
+import FlashMessage from '@src/components/FlashMessage';
 
 const App: React.FC = () => (
   <ApolloProvider client={client}>
     <ThemeProvider theme={theme} useDark={useColorScheme() === 'dark'}>
       <Navigation />
+      <FlashMessage />
     </ThemeProvider>
   </ApolloProvider>
 );

--- a/src/components/FlashMessage.tsx
+++ b/src/components/FlashMessage.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import StackFlashMessage from 'react-native-stack-flash-message';
+import { Icon, Text, useTheme } from 'react-native-elements';
+
+const FlashMessage: React.FC = () => {
+  const {
+    theme: { colors },
+  } = useTheme();
+  const messageWrapperStyle = {
+    borderWidth: 1,
+    borderColor: colors?.greyOutline,
+    backgroundColor: colors?.white,
+  };
+  const theme = {
+    success: colors?.primary || '',
+    info: colors?.success || '',
+    error: colors?.error || '',
+  };
+  const icons = {
+    success: (
+      <Icon
+        name="checkmark-circle-outline"
+        size={20}
+        color={colors?.primary}
+        type="ionicon"
+      />
+    ),
+    info: (
+      <Icon
+        name="information-circle-outline"
+        size={20}
+        color={colors?.success}
+        type="ionicon"
+      />
+    ),
+    error: (
+      <Icon
+        name="close-circle-outline"
+        size={20}
+        color={colors?.error}
+        type="ionicon"
+      />
+    ),
+  };
+
+  return (
+    <StackFlashMessage
+      ref={ref => StackFlashMessage.setRef(ref)}
+      messageWrapperStyle={messageWrapperStyle}
+      titleComponent={Text}
+      contentsComponent={Text}
+      theme={theme}
+      icons={icons}
+    />
+  );
+};
+
+export default FlashMessage;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,0 +1,3 @@
+import StackFlashMessage, { Options } from 'react-native-stack-flash-message';
+
+export const flash = (options: Options) => StackFlashMessage.show(options);

--- a/tests/FlashMessage.test.tsx
+++ b/tests/FlashMessage.test.tsx
@@ -1,0 +1,10 @@
+import 'react-native';
+import React from 'react';
+import renderer from 'react-test-renderer';
+import FlashMessage from '@src/components/FlashMessage';
+
+describe('FlashMessage 컴포넌트', () => {
+  it('렌더링이 올바르게 된다', () => {
+    renderer.create(<FlashMessage />);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7485,6 +7485,18 @@ react-native-size-matters@^0.3.1:
   resolved "https://registry.yarnpkg.com/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz#24d0cfc335a2c730f6d58bd7b43ea5a41be4b49f"
   integrity sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw==
 
+react-native-stack-flash-message@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-stack-flash-message/-/react-native-stack-flash-message-1.3.0.tgz#d92df18fc8dd758480bbdefd5e8b802ce2b376cd"
+  integrity sha512-+culvWPMuWEtVRnLB+4Jb68oG1w+djb+V8AuPtbUR+CxoSZCebgXSyOAs/y4oD+foKyv7nS1K9jtqxqehUrPQg==
+  dependencies:
+    react-native-status-bar-height "^2.6.0"
+
+react-native-status-bar-height@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-native-status-bar-height/-/react-native-status-bar-height-2.6.0.tgz#b6afd25b6e3d533c43d0fcdcfd5cafd775592cea"
+  integrity sha512-z3SGLF0mHT+OlJDq7B7h/jXPjWcdBT3V14Le5L2PjntjjWM3+EJzq2BcXDwV+v67KFNJic5pgA26cCmseYek6w==
+
 react-native-vector-icons@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-8.1.0.tgz#e8ee2b17bc4d9f636da1c6f67feee8e2a850c3d8"


### PR DESCRIPTION
### 작업 개요
[react-native-stack-flash-message](https://github.com/jhs851/react-native-stack-flash-message) 설치

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `react-native-stack-flash-message` 설치
- `FlashMessage` 컴포넌트 생성 및 `App` 컴포넌트에 등록
  - 관련 테스트
- 모든 컴포넌트에서 플래시 메세지를 호출할 수 있는 도움 함수 `flash` 추가

resolve #25

