### PR TITLE
[feat] Fragment

### DIFF
--- a/src/fragments/model.ts
+++ b/src/fragments/model.ts
@@ -1,0 +1,9 @@
+import { gql } from '@apollo/client';
+
+export const MODEL_FIELDS = gql`
+  fragment ModelFields on Model {
+    _id
+    created_at
+    updated_at
+  }
+`;

--- a/src/fragments/plan.ts
+++ b/src/fragments/plan.ts
@@ -1,0 +1,34 @@
+import { gql } from '@apollo/client';
+import { MODEL_FIELDS } from '@src/fragments/model';
+import { CORE_USER_FIELDS } from '@src/fragments/user';
+import { TRAINING_FIELDS } from '@src/fragments/training';
+
+export const SET_FIELDS = gql`
+  fragment SetFields on Set {
+    count
+    weight
+    times
+    distances
+  }
+`;
+
+export const CORE_PLAN_FIELDS = gql`
+  ${MODEL_FIELDS}
+  ${CORE_USER_FIELDS}
+  ${TRAINING_FIELDS}
+  ${SET_FIELDS}
+  fragment CorePlanFields on Plan {
+    ...ModelFields
+    user {
+      ...CoreUserFields
+    }
+    training {
+      ...TrainingFields
+    }
+    plan_date
+    sets {
+      ...SetFields
+    }
+    complete
+  }
+`;

--- a/src/fragments/training.ts
+++ b/src/fragments/training.ts
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client';
+import { MODEL_FIELDS } from '@src/fragments/model';
+
+export const TRAINING_FIELDS = gql`
+  ${MODEL_FIELDS}
+  fragment TrainingFields on Training {
+    ...ModelFields
+    name
+    type
+    description
+    preference
+    thumbnail_path
+    video_path
+  }
+`;

--- a/src/fragments/user.ts
+++ b/src/fragments/user.ts
@@ -1,0 +1,24 @@
+import { gql } from '@apollo/client';
+import { MODEL_FIELDS } from '@src/fragments/model';
+
+export const CORE_USER_FIELDS = gql`
+  ${MODEL_FIELDS}
+  fragment CoreUserFields on User {
+    ...ModelFields
+    name
+    email
+    nickname
+    gender
+    birth
+    tel
+    profile_image_path
+    roles
+  }
+`;
+
+export const LOGIN_RESPONSE_FIELDS = gql`
+  fragment LoginResponseFields on LoginResponse {
+    token
+    refresh_token
+  }
+`;


### PR DESCRIPTION
### 작업 개요
모델들의 기본적인 `Fragment` 선언

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `ModelFields` `Fragment` 선언
- `SetFields` `Fragment` 선언
- `CorePlanFields` `Fragment` 선언
- `TrainingFields` `Fragment` 선언
- `CoreUserFields` `Fragment` 선언
- `LoginResponseFields ` `Fragment` 선언

### 생각해볼 문제
이렇게 일일이 `fragment`들을 선언하는게 맞는것인가?
[graphql-code-generator](https://www.graphql-code-generator.com/)를 사용해서 api쪽에 있는 모델로 `fragment`들을 만들 수도 있을까?

resolve #32

