### PR TITLE
[refactor] 기본적인 Query와 Mutation 선언

### DIFF
--- a/src/hooks/mutations/useCreatePlanMutation.ts
+++ b/src/hooks/mutations/useCreatePlanMutation.ts
@@ -1,0 +1,37 @@
+import { gql, useMutation } from '@apollo/client';
+import { CORE_PLAN_FIELDS } from '@src/fragments/plan';
+import { Mutation, MutationCreatePlanArgs } from '@src/types/graphql';
+import { FetchResult } from '@apollo/client/link/core';
+import {
+  MutationFunctionOptions,
+  MutationResult,
+} from '@apollo/client/react/types/types';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+
+const CREATE_PLAN = gql`
+  ${CORE_PLAN_FIELDS}
+  mutation createPlan($input: PlanInput!) {
+    createPlan(input: $input) {
+      ...CorePlanFields
+    }
+  }
+`;
+
+export function useCreatePlanMutation(): [
+  (
+    options?: MutationFunctionOptions<
+      Mutation['createPlan'],
+      MutationCreatePlanArgs
+    >,
+  ) => Promise<FetchResult<Mutation['createPlan']>>,
+  Pick<MutationResult<Mutation['createPlan']>, 'data' | 'loading'>,
+] {
+  const [createPlan, { data, error, loading }] = useMutation<
+    Mutation['createPlan'],
+    MutationCreatePlanArgs
+  >(CREATE_PLAN);
+
+  useErrorEffect(error);
+
+  return [createPlan, { data, loading }];
+}

--- a/src/hooks/mutations/useDeletePlanMutation.ts
+++ b/src/hooks/mutations/useDeletePlanMutation.ts
@@ -1,0 +1,33 @@
+import { gql, useMutation } from '@apollo/client';
+import {
+  MutationFunctionOptions,
+  MutationResult,
+} from '@apollo/client/react/types/types';
+import { Mutation, MutationDeletePlanArgs } from '@src/types/graphql';
+import { FetchResult } from '@apollo/client/link/core';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+
+const DELETE_PLAN = gql`
+  mutation deletePlan($_id: ObjectId!) {
+    deletePlan(_id: $_id)
+  }
+`;
+
+export function useDeletePlanMutation(): [
+  (
+    options?: MutationFunctionOptions<
+      Mutation['deletePlan'],
+      MutationDeletePlanArgs
+    >,
+  ) => Promise<FetchResult<Mutation['deletePlan']>>,
+  Pick<MutationResult<Mutation['deletePlan']>, 'data' | 'loading'>,
+] {
+  const [deletePlan, { data, error, loading }] = useMutation<
+    Mutation['deletePlan'],
+    MutationDeletePlanArgs
+  >(DELETE_PLAN);
+
+  useErrorEffect(error);
+
+  return [deletePlan, { data, loading }];
+}

--- a/src/hooks/mutations/useLoginMutation.ts
+++ b/src/hooks/mutations/useLoginMutation.ts
@@ -1,0 +1,34 @@
+import { gql, useMutation } from '@apollo/client';
+import { Mutation, MutationLoginArgs } from '@src/types/graphql';
+import { FetchResult } from '@apollo/client/link/core';
+import {
+  MutationFunctionOptions,
+  MutationResult,
+} from '@apollo/client/react/types/types';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+import { LOGIN_RESPONSE_FIELDS } from '@src/fragments/user';
+
+const LOGIN = gql`
+  ${LOGIN_RESPONSE_FIELDS}
+  mutation login($input: LoginInput!) {
+    login(input: $input) {
+      ...LoginResponseFields
+    }
+  }
+`;
+
+export function useLoginMutation(): [
+  (
+    options?: MutationFunctionOptions<Mutation['login'], MutationLoginArgs>,
+  ) => Promise<FetchResult<Mutation['login']>>,
+  Pick<MutationResult<Mutation['login']>, 'data' | 'loading'>,
+] {
+  const [login, { data, error, loading }] = useMutation<
+    Mutation['login'],
+    MutationLoginArgs
+  >(LOGIN);
+
+  useErrorEffect(error);
+
+  return [login, { data, loading }];
+}

--- a/src/hooks/mutations/useRefreshTokenMutation.ts
+++ b/src/hooks/mutations/useRefreshTokenMutation.ts
@@ -1,0 +1,37 @@
+import { gql, useMutation } from '@apollo/client';
+import { Mutation, MutationRefreshTokenArgs } from '@src/types/graphql';
+import { FetchResult } from '@apollo/client/link/core';
+import {
+  MutationFunctionOptions,
+  MutationResult,
+} from '@apollo/client/react/types/types';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+import { LOGIN_RESPONSE_FIELDS } from '@src/fragments/user';
+
+const REFRESH_TOKEN = gql`
+  ${LOGIN_RESPONSE_FIELDS}
+  mutation refreshToken($refresh_token: String!) {
+    refreshToken(refresh_token: $refresh_token) {
+      ...LoginResponseFields
+    }
+  }
+`;
+
+export function useRefreshTokenMutation(): [
+  (
+    options?: MutationFunctionOptions<
+      Mutation['refreshToken'],
+      MutationRefreshTokenArgs
+    >,
+  ) => Promise<FetchResult<Mutation['refreshToken']>>,
+  Pick<MutationResult<Mutation['refreshToken']>, 'data' | 'loading'>,
+] {
+  const [refreshToken, { data, error, loading }] = useMutation<
+    Mutation['refreshToken'],
+    MutationRefreshTokenArgs
+  >(REFRESH_TOKEN);
+
+  useErrorEffect(error);
+
+  return [refreshToken, { data, loading }];
+}

--- a/src/hooks/mutations/useRegisterMutation.ts
+++ b/src/hooks/mutations/useRegisterMutation.ts
@@ -1,0 +1,37 @@
+import { gql, useMutation } from '@apollo/client';
+import { Mutation, MutationRegisterArgs } from '@src/types/graphql';
+import { FetchResult } from '@apollo/client/link/core';
+import {
+  MutationFunctionOptions,
+  MutationResult,
+} from '@apollo/client/react/types/types';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+import { CORE_USER_FIELDS } from '@src/fragments/user';
+
+export const REGISTER = gql`
+  ${CORE_USER_FIELDS}
+  mutation register($input: UserInput!) {
+    register(input: $input) {
+      ...CoreUserFields
+    }
+  }
+`;
+
+export function useRegisterMutation(): [
+  (
+    options?: MutationFunctionOptions<
+      Mutation['register'],
+      MutationRegisterArgs
+    >,
+  ) => Promise<FetchResult<Mutation['register']>>,
+  Pick<MutationResult<Mutation['register']>, 'data' | 'loading'>,
+] {
+  const [register, { data, error, loading }] = useMutation<
+    Mutation['register'],
+    MutationRegisterArgs
+  >(REGISTER);
+
+  useErrorEffect(error);
+
+  return [register, { data, loading }];
+}

--- a/src/hooks/mutations/useSendVerifyEmailMutation.ts
+++ b/src/hooks/mutations/useSendVerifyEmailMutation.ts
@@ -1,0 +1,28 @@
+import { gql, useMutation } from '@apollo/client';
+import { Mutation } from '@src/types/graphql';
+import { FetchResult } from '@apollo/client/link/core';
+import {
+  MutationFunctionOptions,
+  MutationResult,
+} from '@apollo/client/react/types/types';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+
+const SEND_VERIFY_EMAIL = gql`
+  mutation sendVerifyEmail {
+    sendVerifyEmail
+  }
+`;
+
+export function useSendVerifyEmailMutation(): [
+  (
+    options?: MutationFunctionOptions<Mutation['sendVerifyEmail']>,
+  ) => Promise<FetchResult<Mutation['sendVerifyEmail']>>,
+  Pick<MutationResult<Mutation['sendVerifyEmail']>, 'data' | 'loading'>,
+] {
+  const [sendVerifyEmail, { data, error, loading }] =
+    useMutation<Mutation['sendVerifyEmail']>(SEND_VERIFY_EMAIL);
+
+  useErrorEffect(error);
+
+  return [sendVerifyEmail, { data, loading }];
+}

--- a/src/hooks/mutations/useUpdatePlanMutation.ts
+++ b/src/hooks/mutations/useUpdatePlanMutation.ts
@@ -1,0 +1,33 @@
+import { gql, useMutation } from '@apollo/client';
+import {
+  MutationFunctionOptions,
+  MutationResult,
+} from '@apollo/client/react/types/types';
+import { Mutation, MutationUpdatePlanArgs } from '@src/types/graphql';
+import { FetchResult } from '@apollo/client/link/core';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+
+const UPDATE_PLAN = gql`
+  mutation updatePlan($_id: ObjectId!, $input: PlanInput!) {
+    updatePlan(_id: $_id, input: $input)
+  }
+`;
+
+export function useUpdatePlanMutation(): [
+  (
+    options?: MutationFunctionOptions<
+      Mutation['updatePlan'],
+      MutationUpdatePlanArgs
+    >,
+  ) => Promise<FetchResult<Mutation['updatePlan']>>,
+  Pick<MutationResult<Mutation['updatePlan']>, 'data' | 'loading'>,
+] {
+  const [updatePlan, { data, error, loading }] = useMutation<
+    Mutation['updatePlan'],
+    MutationUpdatePlanArgs
+  >(UPDATE_PLAN);
+
+  useErrorEffect(error);
+
+  return [updatePlan, { data, loading }];
+}

--- a/src/hooks/queries/useMeLazyQuery.ts
+++ b/src/hooks/queries/useMeLazyQuery.ts
@@ -1,0 +1,29 @@
+import { gql, useLazyQuery } from '@apollo/client';
+import { Query } from '@src/types/graphql';
+import {
+  LazyQueryResult,
+  QueryLazyOptions,
+} from '@apollo/client/react/types/types';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+import { CORE_USER_FIELDS } from '@src/fragments/user';
+
+const UseMeLazyQuery = gql`
+  ${CORE_USER_FIELDS}
+  query me {
+    me {
+      ...CoreUserFields
+    }
+  }
+`;
+
+export function useMeQuery(): [
+  (options?: QueryLazyOptions<{}>) => void,
+  Pick<LazyQueryResult<Query['me'], {}>, 'data' | 'loading'>,
+] {
+  const [me, { data, error, loading }] =
+    useLazyQuery<Query['me']>(UseMeLazyQuery);
+
+  useErrorEffect(error);
+
+  return [me, { data, loading }];
+}

--- a/src/hooks/queries/usePlansQuery.ts
+++ b/src/hooks/queries/usePlansQuery.ts
@@ -1,0 +1,24 @@
+import { gql, QueryResult, useQuery } from '@apollo/client';
+import { Query } from '@src/types/graphql';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+import { CORE_PLAN_FIELDS } from '@src/fragments/plan';
+
+const PLANS = gql`
+  ${CORE_PLAN_FIELDS}
+  query plans {
+    plans {
+      ...CorePlanFields
+    }
+  }
+`;
+
+export function usePlansQuery(): Pick<
+  QueryResult<Query['plans'], {}>,
+  'data' | 'loading'
+> {
+  const { data, error, loading } = useQuery<Query['plans']>(PLANS);
+
+  useErrorEffect(error);
+
+  return { data, loading };
+}

--- a/src/hooks/queries/useUsersQuery.ts
+++ b/src/hooks/queries/useUsersQuery.ts
@@ -1,0 +1,24 @@
+import { gql, QueryResult, useQuery } from '@apollo/client';
+import { Query } from '@src/types/graphql';
+import { useErrorEffect } from '@src/hooks/useErrorEffect';
+import { CORE_USER_FIELDS } from '@src/fragments/user';
+
+const UseUsersQuery = gql`
+  ${CORE_USER_FIELDS}
+  query users {
+    users {
+      ...CoreUserFields
+    }
+  }
+`;
+
+export function useUsersQuery(): Pick<
+  QueryResult<Query['users'], {}>,
+  'data' | 'loading'
+> {
+  const { data, error, loading } = useQuery<Query['users']>(UseUsersQuery);
+
+  useErrorEffect(error);
+
+  return { data, loading };
+}

--- a/src/hooks/useErrorEffect.ts
+++ b/src/hooks/useErrorEffect.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { flash } from '@src/functions';
+import { ApolloError } from '@apollo/client';
+
+export function useErrorEffect(error?: ApolloError): void {
+  useEffect(() => {
+    if (error) {
+      flash({
+        title: error.name,
+        contents: error.message,
+        type: 'error',
+      });
+    }
+  }, [error]);
+}


### PR DESCRIPTION
### 작업 개요
존재하는 모든 `Mutation`과 뒤늦게 사용할 `Query`를 `hook`으로 생성

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- 모든 `Mutation`들 `hook`으로 생성
- 뒤늦게 사용할 `Query`를 `hook`으로 생성
- `error` 처리는 한곳에서 이루어지도록 `useErrorEffect` `hook` 생성

### 생각해볼 문제
- 이런 아키텍처가 깔끔할지는 아직 잘 모르겠다. 그래도 생각한 것중엔 이게 베스트인 듯. 리서칭할 기회가 생기면 찾아보고 리팩토링 해도 좋을 듯

resolve #34

