### PR TITLE
[feat] KeyboardAvoidingScrollView 컴포넌트

### DIFF
--- a/src/components/KeyboardAvoidingScrollView.tsx
+++ b/src/components/KeyboardAvoidingScrollView.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
+import { HeaderHeightContext } from '@react-navigation/elements';
+
+const KeyboardAvoidingScrollView: React.FC = ({ children }) => {
+  const headerHeight = React.useContext(HeaderHeightContext);
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? headerHeight : 0}>
+      <ScrollView>{children}</ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
+export default KeyboardAvoidingScrollView;

--- a/tests/KeyboardAvoidingScrollView.test.tsx
+++ b/tests/KeyboardAvoidingScrollView.test.tsx
@@ -1,0 +1,12 @@
+import 'react-native';
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import KeyboardAvoidingScrollView from '@src/components/KeyboardAvoidingScrollView';
+
+describe('KeyboardAvoidingScrollView 컴포넌트', () => {
+  it('렌더링이 올바르게 된다', () => {
+    const { toJSON } = render(<KeyboardAvoidingScrollView />);
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/tests/__snapshots__/KeyboardAvoidingScrollView.test.tsx.snap
+++ b/tests/__snapshots__/KeyboardAvoidingScrollView.test.tsx.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KeyboardAvoidingScrollView 컴포넌트 렌더링이 올바르게 된다 1`] = `
+<View
+  onLayout={[Function]}
+  style={
+    Object {
+      "paddingBottom": 0,
+    }
+  }
+>
+  <RCTScrollView>
+    <View />
+  </RCTScrollView>
+</View>
+`;


### PR DESCRIPTION
### 작업 개요
`KeyboardAvoidingScrollView` 컴포넌트 생성

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 시스템 키보드가 올라왔을 때 기존 화면 전체가 스크롤 되도록 하는 `KeyboardAvoidingScrollView` 컴포넌트 생성
- 관련 테스트 작성

resolve #47
