### PR TITLE
[feat] 만료된 JWT 토큰에 대한 처리

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -8,3 +8,8 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+
+# react-native-device-info
+-keepclassmembers class com.android.installreferrer.api.** {
+  *;
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,10 @@ buildscript {
         compileSdkVersion = 30
         targetSdkVersion = 30
         ndkVersion = "21.4.7075529"
+        supportLibVersion = '1.0.2'
+        mediaCompatVersion = '1.0.1'
+        supportV4Version = '1.0.0'
+        firebaseIidVersion = "19.0.1"
     }
     repositories {
         google()

--- a/introspection.json
+++ b/introspection.json
@@ -78,11 +78,33 @@
         "possibleTypes": null
       },
       {
+        "kind": "SCALAR",
+        "name": "JSONObject",
+        "description": "The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "LoginInput",
         "description": "사용자 JWT 토큰 입력 객체",
         "fields": null,
         "inputFields": [
+          {
+            "name": "device_id",
+            "description": "디바이스 ID",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": { "kind": "SCALAR", "name": "String", "ofType": null }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "email",
             "description": "이메일",
@@ -115,7 +137,7 @@
       {
         "kind": "OBJECT",
         "name": "LoginResponse",
-        "description": null,
+        "description": "사용자 JWT 토큰 응답",
         "fields": [
           {
             "name": "refresh_token",
@@ -348,6 +370,22 @@
             "name": "refreshToken",
             "description": "사용자 JWT 토큰 갱신",
             "args": [
+              {
+                "name": "device_id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
               {
                 "name": "refresh_token",
                 "description": null,
@@ -1249,9 +1287,9 @@
           },
           {
             "name": "refresh_token",
-            "description": "JWT Refresh 토큰",
+            "description": "JWT Refresh 토큰 객체 { 디바이스 ID: Refresh 토큰 }",
             "args": [],
-            "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+            "type": { "kind": "SCALAR", "name": "JSONObject", "ofType": null },
             "isDeprecated": false,
             "deprecationReason": null
           },

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -431,6 +431,8 @@ PODS:
     - React-perflogger (= 0.66.0)
   - RNCAsyncStorage (1.15.9):
     - React-Core
+  - RNDeviceInfo (8.4.1):
+    - React-Core
   - RNFBAnalytics (12.9.1):
     - Firebase/Analytics (= 8.8.0)
     - React-Core
@@ -510,6 +512,7 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
+  - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - "RNFBAnalytics (from `../node_modules/@react-native-firebase/analytics`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -610,6 +613,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
+  RNDeviceInfo:
+    :path: "../node_modules/react-native-device-info"
   RNFBAnalytics:
     :path: "../node_modules/@react-native-firebase/analytics"
   RNFBApp:
@@ -681,6 +686,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 4bb657a97aa74568d9ed634c8bd478299bb8a3a6
   ReactCommon: eb059748e842a1a86025ebbd4ac9d99e74492f88
   RNCAsyncStorage: 26f25150da507524a7815f2ada06ca0967f65633
+  RNDeviceInfo: 55175b0bd852c1c5d70d76efc04ed77799cef638
   RNFBAnalytics: 6bf7a27b94a795a688d837763d59090194e9f7c8
   RNFBApp: ece97bfe0a926247591c0aa0bdfe384f06cf46b5
   RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "17.0.2",
     "react-hook-form": "^7.17.2",
     "react-native": "0.66.0",
+    "react-native-device-info": "^8.4.1",
     "react-native-dotenv": "^3.2.0",
     "react-native-elements": "^3.4.2",
     "react-native-paper": "^4.9.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from 'react-native-elements';
 import theme from '@src/theme';
 import { useColorScheme } from 'react-native';
 import { ApolloProvider } from '@apollo/client';
-import { client } from '@src/client';
+import client from '@src/client';
 import FlashMessage from '@src/components/FlashMessage';
 import { RecoilRoot } from 'recoil';
 import Loader from '@src/components/Loader';

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,27 +1,15 @@
 import 'cross-fetch/polyfill';
-import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
-import { APP_API_URI, APP_NAME, APP_VERSION } from '@env';
-import { setContext } from '@apollo/client/link/context';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ApolloClient, from, InMemoryCache } from '@apollo/client';
+import { APP_NAME, APP_VERSION } from '@env';
+import errorLink from '@src/links/errorLink';
+import authLink from '@src/links/authLink';
+import httpLink from '@src/links/httpLink';
 
-const httpLink = createHttpLink({
-  uri: APP_API_URI,
-});
-
-const authLink = setContext(async (_, { headers }) => {
-  const token = await AsyncStorage.getItem('@token');
-
-  return {
-    headers: {
-      ...headers,
-      authorization: token ? `Bearer ${token}` : '',
-    },
-  };
-});
-
-export const client = new ApolloClient({
-  link: authLink.concat(httpLink),
+const client = new ApolloClient({
+  link: from([errorLink, authLink, httpLink]),
   cache: new InMemoryCache(),
   name: APP_NAME,
   version: APP_VERSION,
 });
+
+export default client;

--- a/src/hooks/mutations/useRefreshTokenMutation.ts
+++ b/src/hooks/mutations/useRefreshTokenMutation.ts
@@ -8,7 +8,7 @@ import {
 import { useErrorEffect } from '@src/hooks/useErrorEffect';
 import { LOGIN_RESPONSE_FIELDS } from '@src/fragments/user';
 
-const REFRESH_TOKEN = gql`
+export const REFRESH_TOKEN = gql`
   ${LOGIN_RESPONSE_FIELDS}
   mutation refreshToken($refresh_token: String!) {
     refreshToken(refresh_token: $refresh_token) {

--- a/src/links/authLink.ts
+++ b/src/links/authLink.ts
@@ -1,0 +1,15 @@
+import { setContext } from '@apollo/client/link/context';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const authLink = setContext(async (_, { headers }) => {
+  const token = await AsyncStorage.getItem('@token');
+
+  return {
+    headers: {
+      ...headers,
+      authorization: token ? `Bearer ${token}` : '',
+    },
+  };
+});
+
+export default authLink;

--- a/src/links/errorLink.ts
+++ b/src/links/errorLink.ts
@@ -1,0 +1,76 @@
+import { onError } from '@apollo/client/link/error';
+import { ApolloClient, InMemoryCache, Observable } from '@apollo/client';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { ServerError } from '@apollo/client/link/utils';
+import { ServerParseError } from '@apollo/client/link/http';
+import httpLink from '@src/links/httpLink';
+import { Mutation, MutationRefreshTokenArgs } from '@src/types/graphql';
+import { REFRESH_TOKEN } from '@src/hooks/mutations/useRefreshTokenMutation';
+import { getUniqueId } from 'react-native-device-info';
+
+const isServerError = (
+  error: Error | ServerError | ServerParseError,
+): error is ServerError => (error as ServerError).result !== undefined;
+
+const errorLink = onError(({ networkError, operation, forward }) => {
+  if (
+    networkError &&
+    isServerError(networkError) &&
+    networkError.result.errors[0].extensions.code === 'TOKEN_EXPIRED_ERROR'
+  ) {
+    return new Observable(subscriber => {
+      (async () => {
+        try {
+          const refresh_token = await AsyncStorage.getItem('@refresh_token');
+
+          if (!refresh_token) {
+            await AsyncStorage.multiRemove(['@token', '@refresh_token']);
+            throw new Error('리플래쉬 토큰이 없습니다.');
+          }
+
+          const client = new ApolloClient({
+            link: httpLink,
+            cache: new InMemoryCache(),
+          });
+
+          const { data } = await client.mutate<
+            Pick<Mutation, 'refreshToken'>,
+            MutationRefreshTokenArgs
+          >({
+            mutation: REFRESH_TOKEN,
+            variables: { refresh_token, device_id: getUniqueId() },
+          });
+
+          if (!data) {
+            await AsyncStorage.multiRemove(['@token', '@refresh_token']);
+            throw new Error('올바르지 않은 요청입니다.');
+          }
+
+          const { token, refresh_token: refreshed_token } = data.refreshToken;
+
+          await AsyncStorage.multiSet([
+            ['@token', token],
+            ['@refresh_token', refreshed_token],
+          ]);
+
+          operation.setContext(({ headers = {} }) => ({
+            headers: {
+              ...headers,
+              authorization: token ? `Bearer ${token}` : '',
+            },
+          }));
+
+          forward(operation).subscribe({
+            next: subscriber.next.bind(subscriber),
+            error: subscriber.error.bind(subscriber),
+            complete: subscriber.complete.bind(subscriber),
+          });
+        } catch (error) {
+          subscriber.error(error);
+        }
+      })();
+    });
+  }
+});
+
+export default errorLink;

--- a/src/links/httpLink.ts
+++ b/src/links/httpLink.ts
@@ -1,0 +1,8 @@
+import { createHttpLink } from '@apollo/client';
+import { APP_API_URI } from '@env';
+
+const httpLink = createHttpLink({
+  uri: APP_API_URI,
+});
+
+export default httpLink;

--- a/src/recoils.ts
+++ b/src/recoils.ts
@@ -1,7 +1,7 @@
 import { atom, selector } from 'recoil';
 import { Query, User } from '@src/types/graphql';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { client } from '@src/client';
+import client from '@src/client';
 import { ME } from '@src/hooks/queries/useMeLazyQuery';
 import { flash } from '@src/functions';
 

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -16,6 +16,7 @@ export type Scalars = {
   Int: number;
   Float: number;
   DateTime: any;
+  JSONObject: any;
   ObjectId: any;
 };
 
@@ -25,6 +26,7 @@ export enum Gender {
 }
 
 export type LoginInput = {
+  device_id: Scalars['String'];
   email: Scalars['String'];
   password: Scalars['String'];
 };
@@ -77,6 +79,7 @@ export type MutationLoginArgs = {
 };
 
 export type MutationRefreshTokenArgs = {
+  device_id: Scalars['String'];
   refresh_token: Scalars['String'];
 };
 
@@ -190,7 +193,7 @@ export type User = Model & {
   nickname: Scalars['String'];
   password?: Maybe<Scalars['String']>;
   profile_image_path?: Maybe<Scalars['String']>;
-  refresh_token?: Maybe<Scalars['String']>;
+  refresh_token?: Maybe<Scalars['JSONObject']>;
   roles?: Maybe<Array<Role>>;
   tel?: Maybe<Scalars['String']>;
   updated_at?: Maybe<Scalars['DateTime']>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7797,6 +7797,11 @@ react-native-codegen@^0.0.7:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
+react-native-device-info@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.4.1.tgz#21d1cf0c7bc8476a20c82f0dde968f1660261674"
+  integrity sha512-O+G0wUXAc3196CUAs/C/ugIvIUvTMPvw7gixStZyXOpOGwGQKWx6if1YV1qLD5oPldxSvg17CdgB91yOLniKEA==
+
 react-native-dotenv@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-native-dotenv/-/react-native-dotenv-3.2.0.tgz#3db4674cb56e6572fa8358904b8a58f35e56ff3f"


### PR DESCRIPTION
### 작업 개요
만료된 JWT 토큰 처리

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- api에 `device_id` 값을 보내기 위해 [react-native-device-info](https://github.com/react-native-device-info/react-native-device-info) 설치
- api 변경사항 적용
- `client` 내보내기 default로 변경
- `apollo-client` 링크들 분리
  - `htttpLink`: api 링크 적용
  - `authLink`: 모든 api 요청 헤더에 `token` 포함
  - `errorLink`: 에러 핸들링
    - 만료된 토큰 처리

resolve #53

