### PR TITLE
[feat] Button 컴포넌트

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { ActivityIndicator, TouchableOpacityProps } from 'react-native';
+import styled, { css } from 'styled-components/native';
+import Text, { TextProps } from '@src/components/Text';
+import { useTheme } from '@src/contexts/ThemeProvider';
+
+export type ButtonProps = TouchableOpacityProps &
+  TextProps & {
+    title: string;
+    type?: 'solid' | 'clear' | 'outline';
+    loading?: boolean;
+    disabled?: boolean;
+  };
+
+const RNTouchableOpacity = styled.TouchableOpacity<ButtonProps>`
+  ${({ type = 'solid', theme, color }) =>
+    type === 'solid'
+      ? css`
+          background-color: ${theme[color || 'primary']};
+        `
+      : type === 'outline' &&
+        css`
+          border: 1px solid ${theme[color || 'primary']};
+        `}
+
+  opacity: ${({ disabled }) => (disabled ? 0.6 : 1)};
+  padding: ${({ type }) => (type === 'clear' ? 0 : '6px 12px')};
+`;
+
+const Button: React.FC<ButtonProps> = props => {
+  const { colors } = useTheme();
+
+  return (
+    <RNTouchableOpacity {...props}>
+      {props.loading ? (
+        <ActivityIndicator
+          size={props.size || 16}
+          color={colors[props.color || 'primary']}
+        />
+      ) : (
+        <Text
+          weight={props.weight || 'bold'}
+          color={
+            props.type === undefined || props.type === 'solid'
+              ? 'white'
+              : props.color || 'primary'
+          }>
+          {props.title}
+        </Text>
+      )}
+    </RNTouchableOpacity>
+  );
+};
+
+export default Button;

--- a/src/components/FlashMessage.tsx
+++ b/src/components/FlashMessage.tsx
@@ -9,7 +9,7 @@ const FlashMessage: React.FC = () => {
   const messageWrapperStyle = {
     borderWidth: 1,
     borderColor: colors.greyOutline,
-    backgroundColor: colors.white,
+    backgroundColor: colors.background,
   };
   const theme = {
     success: colors.primary,

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -22,7 +22,7 @@ const Loader: React.FC = () => {
 
   return (
     <LoaderOverlay isVisible={true} fullScreen={true}>
-      <ActivityIndicator size="large" color={colors.black} />
+      <ActivityIndicator size="large" color={colors.foreground} />
       <Title>불러오는 중...😅😅😅</Title>
     </LoaderOverlay>
   );

--- a/src/components/MaterialInput.tsx
+++ b/src/components/MaterialInput.tsx
@@ -54,7 +54,7 @@ const MaterialInput: React.ForwardRefRenderFunction<TextField, P> = (
   return (
     <TextField
       ref={ref}
-      textColor={colors.black}
+      textColor={colors.foreground}
       labelFontSize={14}
       lineWidth={1}
       activeLineWidth={1}

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -15,7 +15,7 @@ export type TextProps = {
 const RNText = styled.Text<Omit<TextProps, 'style'>>`
   font-family: ${({ weight }) => fonts[weight || 'normal']};
   font-size: ${({ size }) => `${size || 16}px`};
-  color: ${({ theme, color }) => theme[color || 'black']};
+  color: ${({ theme, color }) => theme[color || 'foreground']};
 `;
 
 const Text: React.FC<TextProps> = ({

--- a/src/navigations/AppNavigator.tsx
+++ b/src/navigations/AppNavigator.tsx
@@ -14,7 +14,7 @@ const AppNavigator: React.FC = () => {
   const options = {
     title: '',
     headerLeft: () => <Text weight="bold">💪{APP_NAME}</Text>,
-    headerStyle: { backgroundColor: colors.white },
+    headerStyle: { backgroundColor: colors.background },
   };
 
   return (

--- a/src/navigations/MainNavigator.tsx
+++ b/src/navigations/MainNavigator.tsx
@@ -15,7 +15,7 @@ type P = NativeStackScreenProps<RootStackParamList, 'Main'> & {};
 
 const MainNavigator: React.FC<P> = () => {
   const { colors } = useTheme();
-  const barStyle = { backgroundColor: colors.white };
+  const barStyle = { backgroundColor: colors.background };
   const homeOptions: MaterialBottomTabNavigationOptions = {
     tabBarLabel: '홈',
     tabBarIcon: ({ color }) => <Icon name="home" type="oction" color={color} />,

--- a/src/navigations/NavigationContainer.tsx
+++ b/src/navigations/NavigationContainer.tsx
@@ -14,9 +14,9 @@ const NavigationContainer: React.FC = ({ children }) => {
     dark,
     colors: {
       primary: colors.primary,
-      background: colors.white,
-      card: colors.white,
-      text: colors.black,
+      background: colors.background,
+      card: colors.background,
+      text: colors.foreground,
       border: colors.divider,
       notification: colors.error,
     },

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -3,10 +3,10 @@ import { MainTabParamList, RootStackParamList } from '@src/types/navigation';
 import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { CompositeScreenProps } from '@react-navigation/native';
-import { Button } from 'react-native-elements';
 import styled from 'styled-components/native';
 import { flexFillCenter } from '@src/styles/flex';
 import Text from '@src/components/Text';
+import Button from '@src/components/Button';
 
 const Container = styled.View`
   ${flexFillCenter}

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { CompositeScreenProps } from '@react-navigation/native';
 import { AuthStackParamList, RootStackParamList } from '@src/types/navigation';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { Button, Input } from 'react-native-elements';
+import { Input } from 'react-native-elements';
 import Loader from '@src/components/Loader';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { flash } from '@src/functions';
@@ -14,6 +14,7 @@ import styled from 'styled-components/native';
 import { flexFillCenter } from '@src/styles/flex';
 import { getUniqueId } from 'react-native-device-info';
 import Text from '@src/components/Text';
+import Button from '@src/components/Button';
 
 const Container = styled.View`
   ${flexFillCenter}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -3,7 +3,7 @@ import {
   AccentColors,
   CommonColors,
   SocialColors,
-  Themes,
+  Theme,
 } from '@src/types/theme';
 
 export const fonts = {
@@ -24,6 +24,8 @@ const commonColors: CommonColors = {
   greyOutline: '#bbb',
   disabled: 'hsl(208, 8%, 90%)',
   divider: StyleSheet.hairlineWidth < 1 ? '#bcbbc1' : 'rgba(0, 0, 0, 0.12)',
+  foreground: '#000000',
+  background: '#ffffff',
 };
 
 const accentColors: AccentColors = {
@@ -42,7 +44,7 @@ const socialColors: SocialColors = {
   apple: '#000',
 };
 
-const theme: Themes = {
+const theme: Theme = {
   light: {
     ...commonColors,
     ...accentColors,
@@ -52,8 +54,8 @@ const theme: Themes = {
     ...commonColors,
     ...accentColors,
     ...socialColors,
-    white: commonColors.black,
-    black: commonColors.white,
+    foreground: commonColors.background,
+    background: commonColors.foreground,
   },
 };
 

--- a/src/types/theme.ts
+++ b/src/types/theme.ts
@@ -10,6 +10,8 @@ export interface CommonColors {
   readonly greyOutline: string;
   readonly disabled: string;
   readonly divider: string;
+  readonly foreground: string;
+  readonly background: string;
 }
 
 export interface AccentColors {
@@ -30,7 +32,7 @@ export interface SocialColors {
 
 export interface Colors extends CommonColors, AccentColors, SocialColors {}
 
-export type Themes = {
+export type Theme = {
   light: Colors;
   dark: Colors;
 };

--- a/tests/Button.test.tsx
+++ b/tests/Button.test.tsx
@@ -1,0 +1,20 @@
+import 'react-native';
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ThemeProvider from '@src/contexts/ThemeProvider';
+import Button, { ButtonProps } from '@src/components/Button';
+
+describe('Button 컴포넌트', () => {
+  const rendered = (props?: ButtonProps) =>
+    render(
+      <ThemeProvider>
+        <Button title="버튼" {...props} />
+      </ThemeProvider>,
+    );
+
+  it('렌더링이 올바르게 된다', () => {
+    const { toJSON } = rendered();
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+});

--- a/tests/__snapshots__/Button.test.tsx.snap
+++ b/tests/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button 컴포넌트 렌더링이 올바르게 된다 1`] = `
+<View
+  accessible={true}
+  collapsable={false}
+  focusable={false}
+  nativeID="animatedComponent"
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Object {
+      "backgroundColor": "#2089dc",
+      "opacity": 1,
+      "paddingBottom": 6,
+      "paddingLeft": 12,
+      "paddingRight": 12,
+      "paddingTop": 6,
+    }
+  }
+>
+  <Text
+    color="white"
+    style={
+      Array [
+        Object {
+          "color": "#ffffff",
+          "fontFamily": "SpoqaHanSansNeo-Bold",
+          "fontSize": 16,
+        },
+      ]
+    }
+    weight="bold"
+  >
+    버튼
+  </Text>
+</View>
+`;


### PR DESCRIPTION
### 작업 개요
`Button` 컴포넌트 생성

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `Button` 컴포넌트 생성
-  `props`
    - `title`: 버튼 안에 텍스트
    - `type`: `solid`(default), `clear`, `outline`
    - `loading`: 로딩 상태 여부
    - `disabled`: 비활성화 여부

### 생각해볼 문제
- `props`도 쓰면서 `props`의 값 중 하나를 `default` 지정하고 싶은데 어떻게 하는지 모르겠다.
- `title` 대신 아이콘을 쓸 수도 있다.

resolve #59

