### PR TITLE
[feat] 운동 계획 생성 및 수정 시에 3대 운동 업데이트

### DIFF
--- a/src/components/TodayPlan/index.tsx
+++ b/src/components/TodayPlan/index.tsx
@@ -1,6 +1,6 @@
 import { NavigationProp } from '@react-navigation/core/src/types';
 import { useNavigation } from '@react-navigation/native';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { View } from 'react-native';
 
 import Text from '@src/components/Text';
@@ -23,13 +23,12 @@ type P = {
   plan: Plan;
 };
 
-const TodayPlan: React.FC<P> = ({ plan: _plan }) => {
+const TodayPlan: React.FC<P> = ({ plan }) => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
-  const [plan, setPlan] = useState<Plan>(_plan);
   const source = plan.training.thumbnailPath
     ? { uri: plan.training.thumbnailPath }
     : require('@src/resources/images/mock.png');
-  const { loading, onToggleComplete } = useToggleComplete(plan, setPlan);
+  const { loading, onToggleComplete } = useToggleComplete(plan);
   const footerText = useFooterText(plan.volumes || []);
   const edit = useCallback(
     () =>
@@ -39,9 +38,8 @@ const TodayPlan: React.FC<P> = ({ plan: _plan }) => {
       }),
     [navigation, plan.plannedAt],
   );
-  const { editIconProps, completeIconProps } = useIconProps(
-    plan.volumes?.every(volume => volume.complete) || false,
-  );
+  const complete = plan.volumes?.every(volume => volume.complete) || false;
+  const { editIconProps, completeIconProps } = useIconProps(complete);
 
   return (
     <Container>
@@ -60,9 +58,7 @@ const TodayPlan: React.FC<P> = ({ plan: _plan }) => {
         <CompleteButton
           loading={loading}
           onPress={onToggleComplete}
-          complete={
-            plan.volumes && plan.volumes.every(volume => volume.complete)
-          }
+          complete={complete}
           icon={completeIconProps}
         />
       </ButtonGroup>

--- a/src/recoils.ts
+++ b/src/recoils.ts
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atom, selectorFamily } from 'recoil';
 
 import { SBDOneRM } from '@src/operations/queries/getOneRM';
 import { User, Plan } from '@src/types/graphql';
@@ -20,4 +20,21 @@ export const SBDOneRMState = atom<SBDOneRM>({
 export const plansState = atom<Plan[]>({
   key: 'plans',
   default: [],
+});
+
+export const planState = selectorFamily<Plan | undefined, string>({
+  key: 'planState',
+  get:
+    planID =>
+    ({ get }) =>
+      get(plansState).find(({ _id }) => _id === planID),
+  set:
+    planID =>
+    ({ set }, newValue) => {
+      set(plansState, prevPlans =>
+        prevPlans.map(prevPlan =>
+          prevPlan._id === planID ? (newValue as Plan) : prevPlan,
+        ),
+      );
+    },
 });

--- a/src/screens/EditPlanScreen/hooks/useSBDOneRM.ts
+++ b/src/screens/EditPlanScreen/hooks/useSBDOneRM.ts
@@ -1,0 +1,46 @@
+import { useLazyQuery } from '@apollo/client';
+import { OperationVariables } from '@apollo/client/core';
+import { QueryLazyOptions } from '@apollo/client/react/types/types';
+import { CompositeScreenProps } from '@react-navigation/native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import { flash } from '@src/functions';
+import { GET_SBD_ONE_RM, SBDOneRM } from '@src/operations/queries/getOneRM';
+import { SBDOneRMState } from '@src/recoils';
+import {
+  PlanningStackParamList,
+  RootStackParamList,
+} from '@src/types/navigation';
+
+const useSBDOneRM = (
+  navigation: CompositeScreenProps<
+    NativeStackScreenProps<PlanningStackParamList, 'EditPlan'>,
+    NativeStackScreenProps<RootStackParamList>
+  >['navigation'],
+): {
+  getSBDOneRM: (options?: QueryLazyOptions<OperationVariables>) => void;
+} => {
+  const setSBDOneRM = useSetRecoilState<SBDOneRM>(SBDOneRMState);
+
+  const [getSBDOneRM, { data }] = useLazyQuery<SBDOneRM>(GET_SBD_ONE_RM, {
+    fetchPolicy: 'network-only',
+  });
+
+  useEffect(() => {
+    if (data) {
+      setSBDOneRM(data);
+      flash({
+        type: 'success',
+        title: '운동 계획 완료',
+        contents: '운동 계획을 생성했습니다',
+      });
+      navigation.goBack();
+    }
+  }, [data, navigation, setSBDOneRM]);
+
+  return { getSBDOneRM };
+};
+
+export default useSBDOneRM;

--- a/src/screens/EditPlanScreen/hooks/useValidation.ts
+++ b/src/screens/EditPlanScreen/hooks/useValidation.ts
@@ -1,0 +1,42 @@
+import { useRecoilValue } from 'recoil';
+
+import { flash } from '@src/functions';
+import { editingPlans as editingPlansAtom } from '@src/screens/EditPlanScreen/recoils';
+import { EditingPlan } from '@src/types';
+
+const useValidation = (): { validation: () => boolean } => {
+  const editingPlans = useRecoilValue<EditingPlan[]>(editingPlansAtom);
+  const validation = () => {
+    if (editingPlans.some(plan => plan.volumes.length === 0)) {
+      flash({
+        type: 'error',
+        title: '유효성 검사에 실패했습니다.',
+        contents: '볼륨은 하나 이상 추가해야합니다.',
+      });
+
+      return false;
+    }
+
+    if (
+      editingPlans.some(plan =>
+        plan.volumes.some(
+          volume => (volume.count || 0) < 1 || (volume.weight || 0) < 1,
+        ),
+      )
+    ) {
+      flash({
+        type: 'error',
+        title: '유효성 검사에 실패했습니다.',
+        contents: '무게와 개수는 0보다 커야 합니다.',
+      });
+
+      return false;
+    }
+
+    return true;
+  };
+
+  return { validation };
+};
+
+export default useValidation;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -10,7 +10,7 @@ export type RootStackParamList = {
 
 export type MainTabParamList = {
   Home: undefined;
-  Plans: { plannedAt?: string };
+  Plans: { plannedAt?: string } | undefined;
   Profile: undefined;
 };
 


### PR DESCRIPTION
### 작업 개요
운동 계획 생성 및 수정 시에 3대 운동 업데이트가 되도록 변경

### 작업 분류
- [x] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- `Plans` `navigation` 파라미터 `undefined` 허용
- `TodayPlan` 컴포넌트 업데이트 로직 변경
- 운동 계획 생성 및 수정 시에 3대 운동 업데이트
    - 커스텀 훅으로 리팩토링

### 생각해볼 문제
`onCompleted` 쓰지말자 될 때도 있고 안될 때도 있고 진짜 킹받아

resolve #98 

