### PR TITLE
[feat] 운동 계획 삭제 기능

### DIFF
--- a/src/components/EditPlan/hooks/useEvents.ts
+++ b/src/components/EditPlan/hooks/useEvents.ts
@@ -4,7 +4,7 @@ import { DragEndParams } from 'react-native-draggable-flatlist/src/types';
 import { useSetRecoilState } from 'recoil';
 
 import {
-  editingPlans,
+  editingPlansState,
   editingVolumesState,
 } from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan, EditingVolume } from '@src/types';
@@ -17,7 +17,7 @@ const useEvents = (
   onDragEnd: (params: DragEndParams<EditingVolume>) => void;
   addVolume: () => void;
 } => {
-  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlans);
+  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlansState);
   const setEditingVolumes = useSetRecoilState<EditingVolume[]>(
     editingVolumesState(planID),
   );

--- a/src/components/EditPlan/hooks/useEvents.ts
+++ b/src/components/EditPlan/hooks/useEvents.ts
@@ -4,6 +4,7 @@ import { DragEndParams } from 'react-native-draggable-flatlist/src/types';
 import { useSetRecoilState } from 'recoil';
 
 import {
+  deletePlansState,
   editingPlansState,
   editingVolumesState,
 } from '@src/screens/EditPlanScreen/recoils';
@@ -21,6 +22,7 @@ const useEvents = (
   const setEditingVolumes = useSetRecoilState<EditingVolume[]>(
     editingVolumesState(planID),
   );
+  const setDeletePlans = useSetRecoilState<string[]>(deletePlansState);
 
   const toggleAllComplete = useCallback(
     () =>
@@ -35,9 +37,13 @@ const useEvents = (
     [setEditingVolumes],
   );
   const deletePlan = useCallback(
-    (_id: string) =>
-      setEditingPlans(prevState => prevState.filter(plan => plan._id !== _id)),
-    [setEditingPlans],
+    (_id: string) => {
+      setEditingPlans(prevState => prevState.filter(plan => plan._id !== _id));
+      if (isNaN(Number(_id))) {
+        setDeletePlans(prevState => prevState.concat(_id));
+      }
+    },
+    [setDeletePlans, setEditingPlans],
   );
   const onDragEnd = (params: DragEndParams<EditingVolume>) =>
     setEditingVolumes(params.data);

--- a/src/components/PreviousPlansModal/recoils.ts
+++ b/src/components/PreviousPlansModal/recoils.ts
@@ -2,7 +2,7 @@ import { atom } from 'recoil';
 
 import { Plan } from '@src/types/graphql';
 
-export const selectedPlans = atom<Plan[]>({
-  key: 'selectedPlans',
+export const selectedPlansState = atom<Plan[]>({
+  key: 'selectedPlansState',
   default: [],
 });

--- a/src/components/SelectPlan/hooks/useSelect.ts
+++ b/src/components/SelectPlan/hooks/useSelect.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { selectedPlans as selectedPlansAtom } from '@src/components/PreviousPlansModal/recoils';
+import { selectedPlansState } from '@src/components/PreviousPlansModal/recoils';
 import { Plan } from '@src/types/graphql';
 
 const useSelect = (
@@ -11,7 +11,7 @@ const useSelect = (
   onToggleSelect: () => void;
 } => {
   const [selectedPlans, setSelectedPlans] =
-    useRecoilState<Plan[]>(selectedPlansAtom);
+    useRecoilState<Plan[]>(selectedPlansState);
   const selected = selectedPlans.some(
     selectedPlan => selectedPlan._id === plan._id,
   );

--- a/src/components/SelectPlans/hooks/useSelect.ts
+++ b/src/components/SelectPlans/hooks/useSelect.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { selectedPlans as selectedPlansAtom } from '@src/components/PreviousPlansModal/recoils';
+import { selectedPlansState } from '@src/components/PreviousPlansModal/recoils';
 import { Plan } from '@src/types/graphql';
 
 const useSelect = (
@@ -11,7 +11,7 @@ const useSelect = (
   onToggleSelect: () => void;
 } => {
   const [selectedPlans, setSelectedPlans] =
-    useRecoilState<Plan[]>(selectedPlansAtom);
+    useRecoilState<Plan[]>(selectedPlansState);
   const selectedPlansIds = selectedPlans.map(({ _id }) => _id);
   const selected = plans.every(({ _id }) => selectedPlansIds.includes(_id));
 

--- a/src/components/VolumeKeyboard/index.tsx
+++ b/src/components/VolumeKeyboard/index.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil';
 import Text from '@src/components/Text';
 import { useTheme } from '@src/contexts/ThemeProvider';
 import {
-  editingPlans,
+  editingPlansState,
   selectedEditingVolumeIDState,
 } from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
@@ -29,7 +29,7 @@ const VolumeKeyboard: React.FC<P> = () => {
     selectedEditingVolumeIDState,
   );
   const planID =
-    useRecoilValue<EditingPlan[]>(editingPlans).find(plan =>
+    useRecoilValue<EditingPlan[]>(editingPlansState).find(plan =>
       plan.volumes.some(({ _id }) => _id === selectedEditingVolumeID),
     )?._id || '';
 

--- a/src/recoils.ts
+++ b/src/recoils.ts
@@ -18,7 +18,7 @@ export const SBDOneRMState = atom<SBDOneRM>({
 });
 
 export const plansState = atom<Plan[]>({
-  key: 'plans',
+  key: 'plansState',
   default: [],
 });
 

--- a/src/screens/EditPlanScreen/hooks/useDraggableFlistList.tsx
+++ b/src/screens/EditPlanScreen/hooks/useDraggableFlistList.tsx
@@ -11,7 +11,7 @@ import Button from '@src/components/Button';
 import EditPlan from '@src/components/EditPlan';
 import Icon from '@src/components/Icon';
 import Text from '@src/components/Text';
-import { editingPlans as editingPlansAtom } from '@src/screens/EditPlanScreen/recoils';
+import { editingPlansState } from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
 
 import {
@@ -28,7 +28,7 @@ const useDraggableFlistList = (
   renderItem: RenderItem<EditingPlan>;
   ListHeaderComponent: () => ReactElement;
 } => {
-  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlansAtom);
+  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlansState);
 
   const onDragEnd = (params: DragEndParams<EditingPlan>) => {
     setEditingPlans(params.data);

--- a/src/screens/EditPlanScreen/hooks/useFetch.ts
+++ b/src/screens/EditPlanScreen/hooks/useFetch.ts
@@ -6,7 +6,7 @@ import { useRecoilState } from 'recoil';
 
 import { useMultipleCreateOrUpdatePlansMutation } from '@src/operations/mutations/multipleCreateOrUpdatePlans';
 import { plansState } from '@src/recoils';
-import { editingPlans as editingPlansAtom } from '@src/screens/EditPlanScreen/recoils';
+import { editingPlansState } from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
 import { Plan } from '@src/types/graphql';
 import {
@@ -35,7 +35,7 @@ const useFetch = ({
     useMultipleCreateOrUpdatePlansMutation();
   const [plans, setPlans] = useRecoilState<Plan[]>(plansState);
   const [editingPlans, setEditingPlans] =
-    useRecoilState<EditingPlan[]>(editingPlansAtom);
+    useRecoilState<EditingPlan[]>(editingPlansState);
 
   const submit = useCallback(async () => {
     if (validation()) {

--- a/src/screens/EditPlanScreen/hooks/useFetch.ts
+++ b/src/screens/EditPlanScreen/hooks/useFetch.ts
@@ -4,9 +4,13 @@ import dayjs from 'dayjs';
 import { useCallback, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
+import useDeletePlanMutation from '@src/operations/mutations/deletePlan';
 import { useMultipleCreateOrUpdatePlansMutation } from '@src/operations/mutations/multipleCreateOrUpdatePlans';
 import { plansState } from '@src/recoils';
-import { editingPlansState } from '@src/screens/EditPlanScreen/recoils';
+import {
+  deletePlansState,
+  editingPlansState,
+} from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
 import { Plan } from '@src/types/graphql';
 import {
@@ -33,12 +37,23 @@ const useFetch = ({
   const { validation } = useValidation();
   const [multipleCreateOrUpdatePlans, { data, loading }] =
     useMultipleCreateOrUpdatePlansMutation();
+  const [deletePlan] = useDeletePlanMutation();
   const [plans, setPlans] = useRecoilState<Plan[]>(plansState);
   const [editingPlans, setEditingPlans] =
     useRecoilState<EditingPlan[]>(editingPlansState);
+  const [deletePlans, setDeletePlans] =
+    useRecoilState<string[]>(deletePlansState);
 
   const submit = useCallback(async () => {
     if (validation()) {
+      await Promise.all(
+        deletePlans.map(planID =>
+          deletePlan({
+            variables: { _id: planID },
+          }),
+        ),
+      );
+
       await multipleCreateOrUpdatePlans({
         variables: {
           inputs: editingPlans.map(plan => ({
@@ -53,7 +68,14 @@ const useFetch = ({
         },
       });
     }
-  }, [editingPlans, multipleCreateOrUpdatePlans, plannedAt, validation]);
+  }, [
+    deletePlan,
+    deletePlans,
+    editingPlans,
+    multipleCreateOrUpdatePlans,
+    plannedAt,
+    validation,
+  ]);
 
   useEffect(() => {
     const filteredPlans = plans.filter(plan =>
@@ -74,8 +96,6 @@ const useFetch = ({
         })),
       );
     }
-
-    return () => setEditingPlans([]);
   }, [plans, plannedAt, setEditingPlans]);
 
   useEffect(() => {
@@ -86,12 +106,21 @@ const useFetch = ({
         );
 
         return prevPlans
+          .filter(({ _id }) => !deletePlans.includes(_id))
           .filter(({ _id }) => !plansIds.includes(_id))
           .concat(data.multipleCreateOrUpdatePlans);
       });
       getSBDOneRM();
     }
-  }, [data, getSBDOneRM, setEditingPlans, setPlans]);
+  }, [data, deletePlans, getSBDOneRM, setEditingPlans, setPlans]);
+
+  useEffect(
+    () => () => {
+      setEditingPlans([]);
+      setDeletePlans([]);
+    },
+    [setDeletePlans, setEditingPlans],
+  );
 
   return {
     loading,

--- a/src/screens/EditPlanScreen/hooks/useLoad.ts
+++ b/src/screens/EditPlanScreen/hooks/useLoad.ts
@@ -3,8 +3,8 @@ import { MutableRefObject, useCallback, useRef } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { PreviousPlansModalElement } from '@src/components/PreviousPlansModal';
-import { selectedPlans as selectedPlansAtom } from '@src/components/PreviousPlansModal/recoils';
-import { editingPlans as editingPlansAtom } from '@src/screens/EditPlanScreen/recoils';
+import { selectedPlansState } from '@src/components/PreviousPlansModal/recoils';
+import { editingPlansState } from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
 import { Plan } from '@src/types/graphql';
 
@@ -17,8 +17,8 @@ const useLoad = (
 } => {
   const previousPlansModalRef = useRef<PreviousPlansModalElement>(null);
   const [selectedPlans, setSelectedPlans] =
-    useRecoilState<Plan[]>(selectedPlansAtom);
-  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlansAtom);
+    useRecoilState<Plan[]>(selectedPlansState);
+  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlansState);
 
   const showPreviousPlans = useCallback(
     () => previousPlansModalRef.current?.show(),

--- a/src/screens/EditPlanScreen/hooks/useSBDOneRM.ts
+++ b/src/screens/EditPlanScreen/hooks/useSBDOneRM.ts
@@ -34,7 +34,7 @@ const useSBDOneRM = (
       flash({
         type: 'success',
         title: '운동 계획 완료',
-        contents: '운동 계획을 생성했습니다',
+        contents: '운동을 계획 했습니다.',
       });
       navigation.goBack();
     }

--- a/src/screens/EditPlanScreen/hooks/useTraining.tsx
+++ b/src/screens/EditPlanScreen/hooks/useTraining.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { useSetRecoilState } from 'recoil';
 
 import Icon from '@src/components/Icon';
-import { editingPlans as editingPlansAtom } from '@src/screens/EditPlanScreen/recoils';
+import { editingPlansState } from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
 import {
   PlanningStackParamList,
@@ -25,7 +25,7 @@ const useTraining = ({
   node: React.ReactElement;
 } => {
   const { plannedAt } = route.params;
-  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlansAtom);
+  const setEditingPlans = useSetRecoilState<EditingPlan[]>(editingPlansState);
 
   useEffect(() => {
     const trainings = route.params.trainings;

--- a/src/screens/EditPlanScreen/hooks/useValidation.ts
+++ b/src/screens/EditPlanScreen/hooks/useValidation.ts
@@ -1,12 +1,27 @@
 import { useRecoilValue } from 'recoil';
 
 import { flash } from '@src/functions';
-import { editingPlansState } from '@src/screens/EditPlanScreen/recoils';
+import {
+  deletePlansState,
+  editingPlansState,
+} from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
 
 const useValidation = (): { validation: () => boolean } => {
   const editingPlans = useRecoilValue<EditingPlan[]>(editingPlansState);
+  const deletePlans = useRecoilValue<string[]>(deletePlansState);
+
   const validation = () => {
+    if (!editingPlans.length && !deletePlans.length) {
+      flash({
+        type: 'error',
+        title: '유효성 검사에 실패했습니다.',
+        contents: '변경할 사항을 추가해야합니다.',
+      });
+
+      return false;
+    }
+
     if (editingPlans.some(plan => plan.volumes.length === 0)) {
       flash({
         type: 'error',

--- a/src/screens/EditPlanScreen/hooks/useValidation.ts
+++ b/src/screens/EditPlanScreen/hooks/useValidation.ts
@@ -1,11 +1,11 @@
 import { useRecoilValue } from 'recoil';
 
 import { flash } from '@src/functions';
-import { editingPlans as editingPlansAtom } from '@src/screens/EditPlanScreen/recoils';
+import { editingPlansState } from '@src/screens/EditPlanScreen/recoils';
 import { EditingPlan } from '@src/types';
 
 const useValidation = (): { validation: () => boolean } => {
-  const editingPlans = useRecoilValue<EditingPlan[]>(editingPlansAtom);
+  const editingPlans = useRecoilValue<EditingPlan[]>(editingPlansState);
   const validation = () => {
     if (editingPlans.some(plan => plan.volumes.length === 0)) {
       flash({

--- a/src/screens/EditPlanScreen/index.tsx
+++ b/src/screens/EditPlanScreen/index.tsx
@@ -62,7 +62,6 @@ const EditPlanScreen: React.FC<P> = ({ navigation, route }) => {
             title="확인"
             onPress={submit}
             loading={loading}
-            disabled={editingPlans.length === 0}
           />
         </ButtonWrapper>
 

--- a/src/screens/EditPlanScreen/recoils.ts
+++ b/src/screens/EditPlanScreen/recoils.ts
@@ -57,3 +57,8 @@ export const selectedEditingVolumeState = selectorFamily<
       );
     },
 });
+
+export const deletePlansState = atom<string[]>({
+  key: 'deletePlansState',
+  default: [],
+});

--- a/src/screens/EditPlanScreen/recoils.ts
+++ b/src/screens/EditPlanScreen/recoils.ts
@@ -2,21 +2,21 @@ import { atom, selectorFamily } from 'recoil';
 
 import { EditingPlan, EditingVolume } from '@src/types';
 
-export const editingPlans = atom<EditingPlan[]>({
-  key: 'editingPlans',
+export const editingPlansState = atom<EditingPlan[]>({
+  key: 'editingPlansState',
   default: [],
 });
 
 export const editingVolumesState = selectorFamily<EditingVolume[], string>({
-  key: 'editingVolumes',
+  key: 'editingVolumesState',
   get:
     planID =>
     ({ get }) =>
-      get(editingPlans).find(plan => plan._id === planID)?.volumes || [],
+      get(editingPlansState).find(plan => plan._id === planID)?.volumes || [],
   set:
     planID =>
     ({ set }, newValue) => {
-      set(editingPlans, prevValue =>
+      set(editingPlansState, prevValue =>
         prevValue.map(plan =>
           plan._id === planID
             ? {
@@ -30,7 +30,7 @@ export const editingVolumesState = selectorFamily<EditingVolume[], string>({
 });
 
 export const selectedEditingVolumeIDState = atom<string>({
-  key: 'selectedEditingVolumeID',
+  key: 'selectedEditingVolumeIDState',
   default: '',
 });
 

--- a/tests/SelectPlan.test.tsx
+++ b/tests/SelectPlan.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 
-import { selectedPlans } from '@src/components/PreviousPlansModal/recoils';
+import { selectedPlansState } from '@src/components/PreviousPlansModal/recoils';
 import RecoilObserver from '@src/components/RecoilObserver';
 import SelectPlan from '@src/components/SelectPlan';
 import { TrainingType } from '@src/types/graphql';
@@ -30,7 +30,7 @@ describe('SelectPlan 컴포넌트', () => {
   const rendered = () =>
     render(
       <>
-        <RecoilObserver node={selectedPlans} onChange={onChange} />
+        <RecoilObserver node={selectedPlansState} onChange={onChange} />
         <SelectPlan plan={plan} />
       </>,
       { wrapper },

--- a/tests/SelectPlans.test.tsx
+++ b/tests/SelectPlans.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render } from '@testing-library/react-native';
 import dayjs from 'dayjs';
 import React from 'react';
 
-import { selectedPlans } from '@src/components/PreviousPlansModal/recoils';
+import { selectedPlansState } from '@src/components/PreviousPlansModal/recoils';
 import RecoilObserver from '@src/components/RecoilObserver';
 import SelectPlans from '@src/components/SelectPlans';
 import { planFactory, wrapper } from '@tests/functions';
@@ -14,7 +14,7 @@ describe('SelectPlans 컴포넌트', () => {
   const rendered = () =>
     render(
       <>
-        <RecoilObserver node={selectedPlans} onChange={onChange} />
+        <RecoilObserver node={selectedPlansState} onChange={onChange} />
         <SelectPlans plannedAt={plannedAt} plans={plans} />
       </>,
       { wrapper },


### PR DESCRIPTION
### 작업 개요
계획한 운동 삭제

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- recoil state 네이밍 변경
- `deletePlansState` atom 추가
    - submit할 때 `deletePlansState` 내에 planID들을 제거하는 요청

resolve #100 

