### PR TITLE
[fix] 애플 로그인 이슈

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@react-navigation/native-stack": "^6.2.2",
     "dayjs": "^1.10.7",
     "graphql": "^15.6.1",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "polished": "^4.1.3",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6730,6 +6730,11 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"


### PR DESCRIPTION
### 작업 개요
애플 로그인되지 않는 버그 픽스

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- 애플로그인은 최초 로그인시에 `email`, `fullName` 정보를 가져온다
- 이후 로그인에서는 안가져온다. 대신 `identityToken`을 json-decode 하면 `email`은 받아올 수 있다
- 최초 로그인 했을 때 이미 회원가입이 되어있을거라고 판단하고 이름과 닉네임은 mock으로 api 호출한다

resolve #127

