### PR TITLE
[Fix] 운동 계획 순서가 변경되는 이슈

### DIFF
--- a/src/screens/PlansScreen/index.tsx
+++ b/src/screens/PlansScreen/index.tsx
@@ -48,9 +48,19 @@ const PlansScreen: React.FC<P> = ({ navigation, route }) => {
     showDeletePlanModal,
     deletePlans,
   } = useDelete(selectedDate);
-  const plansBySelectedDate = useRecoilValue<PlanType[]>(plansState).filter(
-    ({ plannedAt }) => dayjs(plannedAt).isSame(selectedDate, 'day'),
-  );
+  const plansBySelectedDate = useRecoilValue<PlanType[]>(plansState)
+    .filter(({ plannedAt }) => dayjs(plannedAt).isSame(selectedDate, 'day'))
+    .sort((a, b) => {
+      const trainingNameOfA = a.training.name.toLowerCase();
+      const trainingNameOfB = b.training.name.toLowerCase();
+
+      if (trainingNameOfA < trainingNameOfB) {
+        return -1;
+      } else if (trainingNameOfA > trainingNameOfB) {
+        return 1;
+      }
+      return 0;
+    });
 
   if (!user) {
     return <NeedAuthenticate />;


### PR DESCRIPTION
### 작업 개요
- 운동을 불러오는 시점에 `sort` 로직 추가

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용


### 생각해볼 문제
- 현재는 training.name 으로 정렬하도록 해놓은 상태입니다. 뭔가 운동 순서를 지정하도록 하는 기능을 추가하는 것이 좋을까요 ?


resolve #149 

