### PR TITLE
[fix] 로그인 하지 않은채로 운동 계획

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -171,45 +171,22 @@ PODS:
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.7.2)
-  - kakao-login (4.2.3):
-    - KakaoSDK (= 2.9.0)
-    - KakaoSDKAuth (= 2.9.0)
-    - KakaoSDKCommon (= 2.9.0)
-    - KakaoSDKTalk (= 2.9.0)
-    - KakaoSDKUser (= 2.9.0)
+  - kakao-login (5.2.3):
+    - KakaoSDKAuth (= 2.11.1)
+    - KakaoSDKCommon (= 2.11.1)
+    - KakaoSDKUser (= 2.11.1)
     - React
-  - KakaoSDK (2.9.0):
-    - KakaoSDKAuth (= 2.9.0)
-    - KakaoSDKCommon (= 2.9.0)
-    - KakaoSDKLink (= 2.9.0)
-    - KakaoSDKNavi (= 2.9.0)
-    - KakaoSDKStory (= 2.9.0)
-    - KakaoSDKTalk (= 2.9.0)
-    - KakaoSDKTemplate (= 2.9.0)
-    - KakaoSDKUser (= 2.9.0)
-  - KakaoSDKAuth (2.9.0):
-    - KakaoSDKCommon (= 2.9.0)
-  - KakaoSDKCommon (2.9.0):
-    - KakaoSDKCommon/Common (= 2.9.0)
-    - KakaoSDKCommon/Network (= 2.9.0)
-  - KakaoSDKCommon/Common (2.9.0)
-  - KakaoSDKCommon/Network (2.9.0):
+  - KakaoSDKAuth (2.11.1):
+    - KakaoSDKCommon (= 2.11.1)
+  - KakaoSDKCommon (2.11.1):
+    - KakaoSDKCommon/Common (= 2.11.1)
+    - KakaoSDKCommon/Network (= 2.11.1)
+  - KakaoSDKCommon/Common (2.11.1)
+  - KakaoSDKCommon/Network (2.11.1):
     - Alamofire (~> 5.1)
-    - KakaoSDKCommon/Common (= 2.9.0)
-  - KakaoSDKLink (2.9.0):
-    - KakaoSDKCommon (= 2.9.0)
-    - KakaoSDKTemplate (= 2.9.0)
-  - KakaoSDKNavi (2.9.0):
-    - KakaoSDKCommon/Common (= 2.9.0)
-  - KakaoSDKStory (2.9.0):
-    - KakaoSDKUser (= 2.9.0)
-  - KakaoSDKTalk (2.9.0):
-    - KakaoSDKTemplate (= 2.9.0)
-    - KakaoSDKUser (= 2.9.0)
-  - KakaoSDKTemplate (2.9.0):
-    - KakaoSDKCommon/Common (= 2.9.0)
-  - KakaoSDKUser (2.9.0):
-    - KakaoSDKAuth (= 2.9.0)
+    - KakaoSDKCommon/Common (= 2.11.1)
+  - KakaoSDKUser (2.11.1):
+    - KakaoSDKAuth (= 2.11.1)
   - libevent (2.1.12)
   - libwebp (1.2.1):
     - libwebp/demux (= 1.2.1)
@@ -682,14 +659,8 @@ SPEC REPOS:
     - GoogleUtilities
     - GTMAppAuth
     - GTMSessionFetcher
-    - KakaoSDK
     - KakaoSDKAuth
     - KakaoSDKCommon
-    - KakaoSDKLink
-    - KakaoSDKNavi
-    - KakaoSDKStory
-    - KakaoSDKTalk
-    - KakaoSDKTemplate
     - KakaoSDKUser
     - libevent
     - libwebp
@@ -837,16 +808,10 @@ SPEC CHECKSUMS:
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   GTMAppAuth: 4d8f864896f3646f0c33baf38a28362f4c601e15
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
-  kakao-login: 6c75ad420e66f0708eb109d39212650906bd39f2
-  KakaoSDK: d5a5a38ebf4da97beeecf100ac3dc9a020e19648
-  KakaoSDKAuth: 5d9eec3317320dc60015ba8d597b2ad32fc70b1a
-  KakaoSDKCommon: aaed06bb779b92cd6f5c35e94160d4ecfaaac511
-  KakaoSDKLink: 575d1119427a7b278eb49da656f8d648a0a94411
-  KakaoSDKNavi: 8b767610d59fc044f1f5df3f29c89688a446a1fc
-  KakaoSDKStory: a494a364a3539601289d01aadd117f165f39d7b2
-  KakaoSDKTalk: b0ac197fd7fce4afc9af3f012c1abee7f053c910
-  KakaoSDKTemplate: eaf03ad5e44d374cbfff85588552a5627cd0519c
-  KakaoSDKUser: 37e92bfc1d36b339420952080a8d31c217a38a63
+  kakao-login: d506fe760be606181e206f89bf42fd082720a068
+  KakaoSDKAuth: bb2dfa7be30daa8403c9cfc8001aa6fde7a5b779
+  KakaoSDKCommon: 555e1bb46595b842ded01cf7888cc17bbae4e113
+  KakaoSDKUser: 08c0a4f40bebdebdf948a9e3d0e44ed5c2754f99
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: 98a37e597e40bfdb4c911fc98f2c53d0b12d05fc
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@react-native-community/google-signin": "5.0.0",
     "@react-native-firebase/analytics": "^12.9.1",
     "@react-native-firebase/app": "^12.9.1",
-    "@react-native-seoul/kakao-login": "4.2.3",
+    "@react-native-seoul/kakao-login": "^5.2.3",
     "@react-native-seoul/naver-login": "2.3.0",
     "@react-navigation/bottom-tabs": "^6.0.7",
     "@react-navigation/material-bottom-tabs": "^6.0.7",

--- a/src/components/NeedAuthenticate/NeedAuthenticate.test.tsx
+++ b/src/components/NeedAuthenticate/NeedAuthenticate.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+import { wrapper } from '@tests/functions';
+
+import NeedAuthenticate from './index';
+
+describe('NeedAuthenticate 컴포넌트', () => {
+  const rendered = () => render(<NeedAuthenticate />, { wrapper });
+
+  it('렌더링이 올바르게 된다', () => {
+    const { queryByText } = rendered();
+
+    expect(queryByText('로그인 후 이용 가능합니다!')).not.toBeNull();
+    expect(queryByText('💪')).not.toBeNull();
+    expect(queryByText('로그인 하러가기')).not.toBeNull();
+  });
+});

--- a/src/components/NeedAuthenticate/index.tsx
+++ b/src/components/NeedAuthenticate/index.tsx
@@ -1,0 +1,37 @@
+import { NavigationProp } from '@react-navigation/core/src/types';
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback } from 'react';
+
+import Text from '@src/components/Text';
+import { RootStackParamList } from '@src/types/navigation';
+
+import { Circle, LoginButton, NotLoginContainer } from './styled';
+
+const NeedAuthenticate: React.FC = () => {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const onLogin = useCallback(
+    () =>
+      navigation.navigate('Auth', {
+        screen: 'Login',
+      }),
+    [navigation],
+  );
+
+  return (
+    <NotLoginContainer>
+      <Text weight="bold">로그인 후 이용 가능합니다!</Text>
+      <Circle>
+        <Text size={40}>💪</Text>
+      </Circle>
+      <LoginButton
+        onPress={onLogin}
+        type="outline"
+        color="primary"
+        title="로그인 하러가기"
+        size={12}
+      />
+    </NotLoginContainer>
+  );
+};
+
+export default NeedAuthenticate;

--- a/src/components/NeedAuthenticate/styled.ts
+++ b/src/components/NeedAuthenticate/styled.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components/native';
+
+import Button from '@src/components/Button';
+import { flexCenter, flexFillCenter } from '@src/styles/flex';
+
+export const NotLoginContainer = styled.View`
+  ${flexFillCenter}
+`;
+
+export const Circle = styled.View`
+  width: 100px;
+  height: 100px;
+  border-radius: 50px;
+  background-color: ${({ theme }) => theme.primary};
+  margin-top: 10px;
+  ${flexCenter};
+`;
+
+export const LoginButton = styled(Button)`
+  margin-top: 20px;
+  border-radius: 8px;
+`;

--- a/src/screens/PlansScreen/PlansScreen.test.tsx
+++ b/src/screens/PlansScreen/PlansScreen.test.tsx
@@ -2,10 +2,16 @@ import { navigationMock, navigationNavigateMock } from '@mocks/navigationMocks';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import dayjs from 'dayjs';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 
-import { wrapper } from '@tests/functions';
+import { userFactory, wrapper } from '@tests/functions';
 
 import PlansScreen from './index';
+
+jest.mock('recoil', () => ({
+  ...jest.requireActual('recoil'),
+  useRecoilValue: jest.fn(),
+}));
 
 describe('PlansScreen 컴포넌트', () => {
   const rendered = () =>
@@ -29,6 +35,10 @@ describe('PlansScreen 컴포넌트', () => {
   // });
 
   it('오늘의 운동 계획하기 버튼을 누르면 EditPlan으로 이동한다', async () => {
+    (useRecoilValue as jest.Mock).mockImplementation(({ key }) =>
+      key === 'userState' ? userFactory() : key === 'plansState' ? [] : null,
+    );
+
     const { getByText } = rendered();
 
     await act(async () => fireEvent.press(getByText('오늘의 운동 계획하기')));

--- a/src/screens/PlansScreen/index.tsx
+++ b/src/screens/PlansScreen/index.tsx
@@ -9,10 +9,11 @@ import { useRecoilValue } from 'recoil';
 import Button from '@src/components/Button';
 import ConfirmModal from '@src/components/ConfirmModal';
 import CopyModal from '@src/components/CopyModal';
+import NeedAuthenticate from '@src/components/NeedAuthenticate';
 import Plan from '@src/components/Plan';
 import PlanCalendar from '@src/components/PlanCalendar';
-import { plansState } from '@src/recoils';
-import { Plan as PlanType } from '@src/types/graphql';
+import { plansState, userState } from '@src/recoils';
+import { Plan as PlanType, User } from '@src/types/graphql';
 import { MainTabParamList, RootStackParamList } from '@src/types/navigation';
 
 import useCopy from './hooks/useCopy';
@@ -33,6 +34,7 @@ type P = CompositeScreenProps<
 >;
 
 const PlansScreen: React.FC<P> = ({ navigation, route }) => {
+  const user = useRecoilValue<User | undefined>(userState);
   const { selectedDate, onSelectDate, onPlanning } = useEvents({
     navigation,
     route,
@@ -49,6 +51,10 @@ const PlansScreen: React.FC<P> = ({ navigation, route }) => {
   const plansBySelectedDate = useRecoilValue<PlanType[]>(plansState).filter(
     ({ plannedAt }) => dayjs(plannedAt).isSame(selectedDate, 'day'),
   );
+
+  if (!user) {
+    return <NeedAuthenticate />;
+  }
 
   return (
     <>

--- a/src/screens/ProfileScreen/ProfileScreen.test.tsx
+++ b/src/screens/ProfileScreen/ProfileScreen.test.tsx
@@ -1,5 +1,5 @@
-import { navigationMock, navigationNavigateMock } from '@mocks/navigationMocks';
-import { act, fireEvent, render } from '@testing-library/react-native';
+import { navigationMock } from '@mocks/navigationMocks';
+import { render } from '@testing-library/react-native';
 import React from 'react';
 
 import { wrapper } from '@tests/functions';
@@ -23,15 +23,5 @@ describe('ProfileScreen 컴포넌트', () => {
     const { toJSON } = rendered();
 
     expect(toJSON()).toMatchSnapshot();
-  });
-
-  it('로그인 하지 않은 사용자가 로그인 하러가기 버튼을 누를 수 있다', async () => {
-    const { getByText } = rendered();
-
-    await act(async () => fireEvent.press(getByText('로그인 하러가기')));
-
-    expect(navigationNavigateMock).toHaveBeenCalledWith('Auth', {
-      screen: 'Login',
-    });
   });
 });

--- a/src/screens/ProfileScreen/index.tsx
+++ b/src/screens/ProfileScreen/index.tsx
@@ -2,11 +2,12 @@ import { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
 import { CompositeScreenProps } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import dayjs from 'dayjs';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useRecoilValue } from 'recoil';
 
 import Button from '@src/components/Button';
 import ConfirmModal from '@src/components/ConfirmModal';
+import NeedAuthenticate from '@src/components/NeedAuthenticate';
 import SocialIcon from '@src/components/SocialIcon';
 import Text from '@src/components/Text';
 import { getProfileImage } from '@src/functions';
@@ -19,7 +20,6 @@ import { MainTabParamList, RootStackParamList } from '@src/types/navigation';
 import useLogout from './hooks/useLogout';
 import useWithdrawal from './hooks/useWithdrawal';
 import {
-  Circle,
   Container,
   Divider,
   // EditButton,
@@ -29,10 +29,8 @@ import {
   HeaderContainer,
   Info,
   InfoContainer,
-  LoginButton,
   NicknameContainer,
   NicknameEmailContainer,
-  NotLoginContainer,
   FooterDivider,
   ProfileImage,
 } from './styled';
@@ -42,15 +40,8 @@ type P = CompositeScreenProps<
   NativeStackScreenProps<RootStackParamList>
 >;
 
-const ProfileScreen: React.FC<P> = ({ navigation }) => {
+const ProfileScreen: React.FC<P> = () => {
   const user = useRecoilValue<User | undefined>(userState);
-  const onLogin = useCallback(
-    () =>
-      navigation.navigate('Auth', {
-        screen: 'Login',
-      }),
-    [navigation],
-  );
   // const { editProfileImage, editProfileImageNode } = useEditProfileImage();
   // const { edit, editIconProps } = useEdit();
   const { logout } = useLogout();
@@ -58,21 +49,7 @@ const ProfileScreen: React.FC<P> = ({ navigation }) => {
     useWithdrawal();
 
   if (!user) {
-    return (
-      <NotLoginContainer>
-        <Text weight="bold">로그인 후 이용 가능합니다!</Text>
-        <Circle>
-          <Text size={40}>💪</Text>
-        </Circle>
-        <LoginButton
-          onPress={onLogin}
-          type="outline"
-          color="primary"
-          title="로그인 하러가기"
-          size={12}
-        />
-      </NotLoginContainer>
-    );
+    return <NeedAuthenticate />;
   }
 
   return (

--- a/src/screens/ProfileScreen/styled.ts
+++ b/src/screens/ProfileScreen/styled.ts
@@ -3,25 +3,7 @@ import styled from 'styled-components/native';
 import Button from '@src/components/Button';
 import Image from '@src/components/Image';
 import Text from '@src/components/Text';
-import { flexCenter, flexFillCenter } from '@src/styles/flex';
-
-export const NotLoginContainer = styled.View`
-  ${flexFillCenter}
-`;
-
-export const Circle = styled.View`
-  width: 100px;
-  height: 100px;
-  border-radius: 50px;
-  background-color: ${({ theme }) => theme.primary};
-  margin-top: 10px;
-  ${flexCenter};
-`;
-
-export const LoginButton = styled(Button)`
-  margin-top: 20px;
-  border-radius: 8px;
-`;
+import { flexCenter } from '@src/styles/flex';
 
 export const Container = styled.View`
   flex: 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,10 +2083,10 @@
     opencollective-postinstall "^2.0.1"
     superstruct "^0.6.2"
 
-"@react-native-seoul/kakao-login@4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@react-native-seoul/kakao-login/-/kakao-login-4.2.3.tgz#70a04151c501ba2f4a5fc91a128375f89425e8d2"
-  integrity sha512-r1SdCi2xxvzZ+nDxIZr8dZttOw2FZEoK093MrfDjAQ8EI2gcnMvWJrssb691Vo5WLh+niZmqNgczmIE2J7nFqQ==
+"@react-native-seoul/kakao-login@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@react-native-seoul/kakao-login/-/kakao-login-5.2.3.tgz#d5f51d9b544073ac189a43fc79e85063ad0f40d2"
+  integrity sha512-LMdzlw/SguL4lvbXUfRBDvMlDRCsZi4e98bufl8gEhc+ScEKq5iS62Yj/sjDj7S6sR8G8KJQ0yHRgKgkyf5i5g==
   dependencies:
     dooboolab-welcome "^1.3.2"
 


### PR DESCRIPTION
### 작업 개요
- xcode 14 에서 react-native-kakao-login 빌드 에러 해결
    - 해당 에러 이슈 해결로 인해 pod 업데이트가 필요합니다 cc @jiyaaany 
    - `pod update KakaoSDKCommon KakaoSDKUser KakaoSDKAuth`
- 로그인을 하지 않고 계획 페이지로 접속 했을 때는 내정보 페이지와 동일하게 노출

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `react-native-kakao-login` 버전 업데이트
- `NeedAuthenticate` 컴포넌트 생성
    - 관련 테스트 작성 

resolve #141

